### PR TITLE
Add alt text to logo and fix HelpBox margin

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,7 +6,7 @@ function App() {
     <>
       <header>
         <div id="logo-img">
-          <img src={logo} />
+          <img src={logo} alt="GitHub Actions logo" />
         </div>
         <h1>Learn & Master GitHub Actions</h1>
       </header>

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -1,0 +1,12 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+
+import App from './App';
+
+describe('App', () => {
+  it('renders the logo with descriptive alt text', () => {
+    render(<App />);
+    const logo = screen.getByRole('img', { name: /github actions logo/i });
+    expect(logo).toBeInTheDocument();
+  });
+});

--- a/src/components/HelpBox.css
+++ b/src/components/HelpBox.css
@@ -1,7 +1,7 @@
 .help-box {
   padding: 1rem;
   border-radius: 4px;
-  margin: 1;
+  margin: 1rem;
   flex: 1;
 }
 


### PR DESCRIPTION
## Summary
- add accessible alt text to header logo
- fix HelpBox CSS by adding missing rem unit to margin
- test for rendering the logo with alt text

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6895ef1b6ab083279d1c3ff39d7ae42d