### PR TITLE
Fix cached-deps composite action output variable

### DIFF
--- a/.github/actions/cached-deps/action.yaml
+++ b/.github/actions/cached-deps/action.yaml
@@ -26,7 +26,7 @@ runs:
     - name: Install dependencies
       id: install
       if: steps.cache.outputs.cache-hit != 'true'  || inputs.caching == 'true' ## if cache is not hit, then install dependencies
-      run: | 
+      run: |
            npm ci
-           echo "cache='${{ input.caching }}'" >> $GITHUB_OUTPUTS ## this will be used to check if cache is hit or not
+           echo "cache=${{ steps.cache.outputs.cache-hit }}" >> "$GITHUB_OUTPUT" ## this will be used to check if cache is hit or not
       shell: bash


### PR DESCRIPTION
## Summary
- fix composite action to reference cache output and GITHUB_OUTPUT correctly

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689885bb8b18832799d6edd31a5ba2d3