### PR TITLE
Fix local S3 deploy action usage in workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -79,13 +79,12 @@ jobs:
       - name: Output contents
         run: ls
       - name: Deploy site
-        uses: ./.github/actions/deploy-s3-javascript
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        uses: ./.github/deploy-s3-javascript
         with:
           bucket: my-s3-bucket-name
           region: us-east-1
+          accessKeyId: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          secretAccessKey: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           sourceDir: ./dist
   Information:
     runs-on: ubuntu-latest
@@ -94,5 +93,11 @@ jobs:
         uses: actions/checkout@v4
       - name: Run customaction
         uses: ./.github/deploy-s3-javascript ## relevent to root folder of the repo
+        with:
+          bucket: demo-bucket
+          region: us-east-1
+          accessKeyId: FAKE
+          secretAccessKey: FAKE
+          sourceDir: ./dist
         # or if you want to use it from an existing repo, you can use the following
         ##uses: accountname/reponame  (format incase of using it from exsisting repo)


### PR DESCRIPTION
## Summary
- point deploy job to existing `deploy-s3-javascript` action
- supply required AWS inputs for deploy and sample job

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68998eae66d4832786ee5bc3ba2f9372