### PR TITLE
Add MongoDB test workflow with cached deps

### DIFF
--- a/.github/workflows/mongodb-test.yml
+++ b/.github/workflows/mongodb-test.yml
@@ -1,0 +1,25 @@
+name: mongodb-test
+on:
+  push:
+    branches:
+      - master
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    services:
+      mongo:
+        image: mongo:latest
+        ports:
+          - 27017:27017
+        options: >-
+          --health-cmd='mongosh --eval "db.adminCommand(\'ping\')"'
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Load and cache dependencies
+        uses: ./.github/actions/cached-deps
+      - name: Run tests
+        run: npm test


### PR DESCRIPTION
## Summary
- run MongoDB service tests in CI
- ensure repository is checked out before using local cached-deps action

## Testing
- `npm ci`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689f941fbb488327bd7240218a884344